### PR TITLE
Bug Fix: Allow Audio Transcription of Longer Files

### DIFF
--- a/src/backend/upload/AudioTranscriber.py
+++ b/src/backend/upload/AudioTranscriber.py
@@ -27,7 +27,6 @@ class AudioTranscriber:
             :return str: the transcribed text
         """
         audio = whisper.load_audio(audio_filepath)
-        audio = whisper.pad_or_trim(audio)
 
         result = whisper.transcribe(model=self.model, audio=audio)
         return result["text"]


### PR DESCRIPTION
- Addresses issue where uploaded audio files longer than 30 seconds would be trimmed to 30 seconds before audio transcription. 
- Removes whisper pad_or_trim method which cut down audio files to 30 seconds
- Allows for the whole of audio files longer than 30 seconds to be transcribed