### PR TITLE
Fixed a bug in which new directories were not being created in the server.

### DIFF
--- a/backend/upload/DocumentUploader.py
+++ b/backend/upload/DocumentUploader.py
@@ -41,12 +41,9 @@ class DocumentUploader:
 
     def __save_file(self, file):
         try:
-            os.makedirs('uploads', exist_ok=True)
-            # Make sure the uploads directory exists
-
             filename = file.filename
-
             filepath = os.path.join('uploads', filename)
+            os.makedirs(os.path.dirname(filepath), exist_ok=True)
             file.save(filepath)
 
             self.__process_file(filepath, filename)

--- a/frontend/src/components/UploadFileButton.tsx
+++ b/frontend/src/components/UploadFileButton.tsx
@@ -39,13 +39,12 @@ const UploadFileButton : FC<UploadFileButtonProps> = ({ onFileSelected, onUpload
         if ( !files ) return;
 
         const formData = new FormData();
-
-      for ( let idx = 0; idx < files.length; idx++ ) {
-        const file = files[idx];
-        formData.append("files[]", file);
-        onFileSelected?.(file);
-      }
-
+        
+        for ( let idx = 0; idx < files.length; idx++ ) {
+            const file = files[idx];
+            formData.append("files[]", file);
+            onFileSelected?.(file);
+        }
 
         folder ? setIsFolderUploading(true) : setIsUploading(true);
 


### PR DESCRIPTION
The server was only creating the "uploads" directory.

This was fine when directory upload was unsupported. Now that it is, we need to ensure that the server is constructing the full directory path to the files that are being uploaded (akin to a mkdir -p).

Thanks for the bug report, Luka.